### PR TITLE
Fix switches not associated with a BoW

### DIFF
--- a/custom_components/omnilogic/switch.py
+++ b/custom_components/omnilogic/switch.py
@@ -125,9 +125,14 @@ class OmniLogicRelayControl(OmniLogicSwitch):
         self._last_action = time.time()
         self.async_write_ha_state()
 
+        """ Patch: determine case where the switch/relay is not associated with a bow """
+        bow_id = int(self._item_id[3])
+        if len(self._item_id) == 4:
+            bow_id = 0
+
         await self.coordinator.api.set_relay_valve(
             int(self._item_id[1]),
-            int(self._item_id[3]),
+            bow_id,
             int(self._item_id[-1]),
             1,
         )
@@ -138,9 +143,14 @@ class OmniLogicRelayControl(OmniLogicSwitch):
         self._last_action = time.time()
         self.async_write_ha_state()
 
+        """ Patch: determine case where the switch/relay is not associated with a bow """
+        bow_id = int(self._item_id[3])
+        if len(self._item_id) == 4:
+            bow_id = 0
+            
         await self.coordinator.api.set_relay_valve(
             int(self._item_id[1]),
-            int(self._item_id[3]),
+            bow_id,
             int(self._item_id[-1]),
             0,
         )

--- a/custom_components/omnilogic/switch.py
+++ b/custom_components/omnilogic/switch.py
@@ -147,7 +147,7 @@ class OmniLogicRelayControl(OmniLogicSwitch):
         bow_id = int(self._item_id[3])
         if len(self._item_id) == 4:
             bow_id = 0
-            
+
         await self.coordinator.api.set_relay_valve(
             int(self._item_id[1]),
             bow_id,


### PR DESCRIPTION
Patch to pass 0 for the PoolID to control a switch/relay which is not associated with a BoW, such as Backyard lights.  I am not sure whether the condition "len(self._item_id) == 4" is optimal but it has worked for me. 