### PR TITLE
Add Instant Salt sensor, opt in to long term statistics, update sync_setup_setups due to deprecation, implement change to login credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Enjoy!
 
 There is currently support for the following device types within Home Assistant:
 
-- ***Sensor*** - Air Temperature, Water Temperature, Variable Pump Speed, Chlorinator Setting, Salt Level, pH, and ORP
+- ***Sensor*** - Air Temperature, Water Temperature, Variable Pump Speed, Chlorinator Setting, Instant and Average Salt Levels, pH, and ORP. Note that the Omnilogic controller allows temperature sensors to be renamed; sensors must be left at the default naming convention for the integration to properly recognize them (airTemp, waterTemp, etc.)
 - ***Switch*** - All relays, pumps (single, dual, variable speed), and relay-based lights.
 - ***Light*** - Colorlogic Lights (V1 and V2).
 - ***Water Heater*** - Pool heaters of different types.
@@ -57,7 +57,7 @@ Review the [Wiki](https://github.com/djtimca/haomnilogic/wiki) for tips on how I
 
 ## Sensor Platform Options
 
-If you have pH sensors in your Omnilogic setup, you can add an offset to correct reporting from the sensor in the integration configuration. 
+If you have pH sensors in your Omnilogic setup, you can add an offset to correct reporting from the sensor in the integration configuration.
 
 Go to the Integrations page in setup and choose 'Configure' to adjust your offsets.
 

--- a/custom_components/omnilogic/__init__.py
+++ b/custom_components/omnilogic/__init__.py
@@ -18,7 +18,13 @@ from .const import (
     OMNI_API,
 )
 
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.LIGHT, Platform.WATER_HEATER, Platform.BINARY_SENSOR]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.LIGHT,
+    Platform.WATER_HEATER,
+    Platform.BINARY_SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -59,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         OMNI_API: api,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/omnilogic/sensor.py
+++ b/custom_components/omnilogic/sensor.py
@@ -1,5 +1,9 @@
 """Definition and setup of the Omnilogic Sensors for Home Assistant."""
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    STATE_CLASS_MEASUREMENT,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
@@ -45,6 +49,7 @@ async def async_setup_entry(
                     kind=entity_setting["kind"],
                     item_id=item_id,
                     device_class=entity_setting["device_class"],
+                    state_class=entity_setting["state_class"],
                     icon=entity_setting["icon"],
                     unit=entity_setting["unit"],
                 )
@@ -63,6 +68,7 @@ class OmnilogicSensor(OmniLogicEntity, SensorEntity):
         kind: str,
         name: str,
         device_class: str,
+        state_class: str,
         icon: str,
         unit: str,
         item_id: tuple,
@@ -82,6 +88,7 @@ class OmnilogicSensor(OmniLogicEntity, SensorEntity):
 
         self._unit_type = unit_type
         self._device_class = device_class
+        self._state_class = state_class
         self._unit = unit
         self._state_key = state_key
 
@@ -89,6 +96,11 @@ class OmnilogicSensor(OmniLogicEntity, SensorEntity):
     def device_class(self):
         """Return the device class of the entity."""
         return self._device_class
+
+    @property
+    def state_class(self):
+        """Return the state class of the entity."""
+        return self._state_class
 
     @property
     def native_unit_of_measurement(self):
@@ -221,6 +233,7 @@ class OmniLogicORPSensor(OmnilogicSensor):
         kind: str,
         item_id: tuple,
         device_class: str,
+        state_class: str,
         icon: str,
         unit: str,
     ) -> None:
@@ -230,6 +243,7 @@ class OmniLogicORPSensor(OmnilogicSensor):
             kind=kind,
             name=name,
             device_class=device_class,
+            state_class=state_class,
             icon=icon,
             unit=unit,
             item_id=item_id,
@@ -255,6 +269,7 @@ SENSOR_TYPES = {
             "name": "Air Temperature",
             "kind": "air_temperature",
             "device_class": SensorDeviceClass.TEMPERATURE,
+            "state_class": STATE_CLASS_MEASUREMENT,
             "icon": None,
             "unit": TEMP_FAHRENHEIT,
             "native_unit_of_measurement": TEMP_FAHRENHEIT,
@@ -267,6 +282,7 @@ SENSOR_TYPES = {
             "name": "Water Temperature",
             "kind": "water_temperature",
             "device_class": SensorDeviceClass.TEMPERATURE,
+            "state_class": STATE_CLASS_MEASUREMENT,
             "icon": None,
             "unit": TEMP_FAHRENHEIT,
             "native_unit_of_measurement": TEMP_FAHRENHEIT,
@@ -279,6 +295,7 @@ SENSOR_TYPES = {
             "name": "Speed",
             "kind": "filter_pump_speed",
             "device_class": None,
+            "state_class": None,
             "icon": "mdi:speedometer",
             "unit": PERCENTAGE,
             "guard_condition": [
@@ -292,6 +309,7 @@ SENSOR_TYPES = {
             "name": "Pump Speed",
             "kind": "pump_speed",
             "device_class": None,
+            "state_class": None,
             "icon": "mdi:speedometer",
             "unit": PERCENTAGE,
             "guard_condition": [
@@ -305,6 +323,7 @@ SENSOR_TYPES = {
             "name": "Setting",
             "kind": "chlorinator",
             "device_class": None,
+            "state_class": None,
             "icon": "mdi:gauge",
             "unit": PERCENTAGE,
             "guard_condition": [
@@ -322,6 +341,7 @@ SENSOR_TYPES = {
             "name": "Average Salt Level",
             "kind": "average_salt_level",
             "device_class": None,
+            "state_class": STATE_CLASS_MEASUREMENT,
             "icon": "mdi:gauge",
             "unit": CONCENTRATION_PARTS_PER_MILLION,
             "guard_condition": [
@@ -336,6 +356,7 @@ SENSOR_TYPES = {
             "name": "Instant Salt Level",
             "kind": "instant_salt_level",
             "device_class": None,
+            "state_class": STATE_CLASS_MEASUREMENT,
             "icon": "mdi:gauge",
             "unit": CONCENTRATION_PARTS_PER_MILLION,
             "guard_condition": [
@@ -352,6 +373,7 @@ SENSOR_TYPES = {
             "name": "pH",
             "kind": "csad_ph",
             "device_class": None,
+            "state_class": STATE_CLASS_MEASUREMENT,
             "icon": "mdi:gauge",
             "unit": "pH",
             "guard_condition": [
@@ -363,6 +385,7 @@ SENSOR_TYPES = {
             "name": "ORP",
             "kind": "csad_orp",
             "device_class": None,
+            "state_class": STATE_CLASS_MEASUREMENT,
             "icon": "mdi:gauge",
             "unit": ELECTRIC_POTENTIAL_MILLIVOLT,
             "guard_condition": [

--- a/custom_components/omnilogic/sensor.py
+++ b/custom_components/omnilogic/sensor.py
@@ -319,8 +319,22 @@ SENSOR_TYPES = {
         },
         {
             "entity_classes": {"avgSaltLevel": OmniLogicSaltLevelSensor},
-            "name": "Salt Level",
-            "kind": "salt_level",
+            "name": "Average Salt Level",
+            "kind": "average_salt_level",
+            "device_class": None,
+            "icon": "mdi:gauge",
+            "unit": CONCENTRATION_PARTS_PER_MILLION,
+            "guard_condition": [
+                {
+                    "Shared-Type": "BOW_SHARED_EQUIPMENT",
+                    "status": "0",
+                },
+            ],
+        },
+        {
+            "entity_classes": {"instantSaltLevel": OmniLogicSaltLevelSensor},
+            "name": "Instant Salt Level",
+            "kind": "instant_salt_level",
             "device_class": None,
             "icon": "mdi:gauge",
             "unit": CONCENTRATION_PARTS_PER_MILLION,

--- a/custom_components/omnilogic/strings.json
+++ b/custom_components/omnilogic/strings.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "data": {
-          "username": "Username (not email)",
+          "username": "Username",
           "password": "Password"
         }
       }

--- a/custom_components/omnilogic/strings.json
+++ b/custom_components/omnilogic/strings.json
@@ -22,8 +22,10 @@
     "step": {
       "init": {
         "data": {
-          "polling_interval": "Polling interval (in seconds)",
-          "ph_offset": "pH offset (positive or negative)"
+          "username": "Username",
+          "password": "Password",
+          "polling_interval": "Polling interval (seconds, default=30)",
+          "ph_offset": "pH offset (+14 to -14)"
         }
       }
     }

--- a/custom_components/omnilogic/translations/en.json
+++ b/custom_components/omnilogic/translations/en.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "data": {
-          "username": "Username (not email)",
+          "username": "Username",
           "password": "Password"
         }
       }

--- a/custom_components/omnilogic/translations/en.json
+++ b/custom_components/omnilogic/translations/en.json
@@ -22,8 +22,10 @@
     "step": {
       "init": {
         "data": {
-          "polling_interval": "Polling interval (in seconds)",
-          "ph_offset": "pH offset (positive or negative)"
+          "username": "Username",
+          "password": "Password",
+          "polling_interval": "Polling interval (seconds, default=30)",
+          "ph_offset": "pH offset (+14 to -14)"
         }
       }
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename previous Salt Level sensor to Average Salt Level and add new sensor for Instant Salt Level as the Hayward API does expose this in the returned telemetry.

Add note to Readme that sensors should not be renamed within the Omnilogic controller configuration.

Removed '(not email)' string from Username prompt, as email addresses are possible for credentials.

Update waiting for config entry platform: before 2022.8, it was impossible to await config entry platforms forwards without a deadlock if one of the platforms loaded by the config entry was not already loaded. Replaced async_setup_platforms with await async_forward_entry_setups, as the former will be removed in 2023.3.
https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/

Add STATE_CLASS to all measurement sensors to enable long term statistics in HA.

Add Username and Password login credentials to integration Options config flow. This allows changing of Hayward Omnilogic login credentials without having to delete and reinstall integration. To maintain compatibility with existing integrations, write both credential data and options data to both Data and Options config entries. Bound pH Offset to -14 to +14.

## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Existing integrations will have their Salt Level Sensor orphaned and replaced with the two new sensors, Average Salt Level and Instant Salt Level

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality to an this integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR implements this requested feature: https://github.com/djtimca/haomnilogic/issues/41
- This PR implements this requested feature: https://github.com/djtimca/haomnilogic/issues/35
- This PR implements this requested feature: https://github.com/djtimca/haomnilogic/issues/42
- This PR is related to issue: https://github.com/djtimca/haomnilogic/issues/33

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] The code has been formatted using Black (`black --fast custom_components`)
- [X] Documentation added/updated to README.md

Note that this is my first PR; apologies if anything is incorrect or I didn't follow proper etiquette!