### PR TITLE
Upgraded calls to deprecated functions

### DIFF
--- a/custom_components/omnilogic/__init__.py
+++ b/custom_components/omnilogic/__init__.py
@@ -59,14 +59,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         OMNI_API: api,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    hass.config_entries.async_forward_entry_setup(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
 


### PR DESCRIPTION
The following PR resolves the issue mentioned in https://github.com/djtimca/haomnilogic/issues/46, and referenced in the following blog post from the HA team.

Upgraded calls to older deprecated functions
- `async_setup_platforms` => `async_forward_entry_setup`
- `async_unload_platforms` => `async_forward_entry_unload`